### PR TITLE
docs(daily): add openapi for schedule daily

### DIFF
--- a/public/openapi.json
+++ b/public/openapi.json
@@ -142,10 +142,12 @@
                                             "type": "object",
                                             "properties": {
                                                 "province": {
-                                                    "type": "string"
+                                                    "type": "string",
+                                                    "example": "JAWA BARAT"
                                                 },
                                                 "city": {
-                                                    "type": "string"
+                                                    "type": "string",
+                                                    "example": "KOTA BANDUNG"
                                                 },
                                                 "schedules": {
                                                     "type": "array",


### PR DESCRIPTION
add openapi documentaiton for new endpoint schedule daily

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API bumped to v1.1.0; schedule endpoints updated with new query parameters for daily and monthly requests.
  * Daily endpoint requires a date and now returns a single schedule object.
  * Monthly endpoint accepts province_id, city_id, month, year and returns a structured object with province, city, and schedules array.
* **Documentation**
  * Response examples and schema examples updated to reflect new structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->